### PR TITLE
Fix useEffect dependency for overlay event listeners

### DIFF
--- a/client/src/components/mushroom-map.tsx
+++ b/client/src/components/mushroom-map.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -156,7 +156,7 @@ function WMSLayer({
         }
       }
     };
-  }, [map, url, layers, format, transparent, opacity, attribution, onLoad, onError]);
+  }, [map, url, layers, format, transparent, opacity, attribution]);
 
   return null;
 }
@@ -235,7 +235,7 @@ export default function MushroomMap({ center, locations, radius }: MushroomMapPr
   };
 
   // Handle overlay load success
-  const handleOverlayLoad = (overlayName: keyof OverlayLoadingState) => {
+  const handleOverlayLoad = useCallback((overlayName: keyof OverlayLoadingState) => {
     setOverlayLoading(prev => ({
       ...prev,
       [overlayName]: false
@@ -244,10 +244,10 @@ export default function MushroomMap({ center, locations, radius }: MushroomMapPr
       ...prev,
       [overlayName]: false
     }));
-  };
+  }, []);
 
   // Handle overlay load error
-  const handleOverlayError = (overlayName: keyof OverlayErrorState, error: any) => {
+  const handleOverlayError = useCallback((overlayName: keyof OverlayErrorState, error: any) => {
     setOverlayLoading(prev => ({
       ...prev,
       [overlayName]: false
@@ -257,7 +257,7 @@ export default function MushroomMap({ center, locations, radius }: MushroomMapPr
       [overlayName]: true
     }));
     console.error(`Overlay ${overlayName} failed to load:`, error);
-  };
+  }, []);
 
   // Get selected base layer configuration
   const currentBaseLayer = BASE_LAYERS.find(layer => layer.id === selectedBaseLayer) || BASE_LAYERS[0];

--- a/client/src/components/mushroom-map.tsx
+++ b/client/src/components/mushroom-map.tsx
@@ -156,7 +156,7 @@ function WMSLayer({
         }
       }
     };
-  }, [map, url, layers, format, transparent, opacity, attribution]);
+  }, [map, url, layers, format, transparent, opacity, attribution, onLoad, onError]);
 
   return null;
 }

--- a/client/src/pages/profile.tsx
+++ b/client/src/pages/profile.tsx
@@ -1,5 +1,6 @@
 import MobileHeader from "@/components/mobile-header";
 import BottomNavigation from "@/components/bottom-navigation";
+import { SwissFungiPanel } from "@/components/SwissFungiPanel";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -240,6 +241,9 @@ export default function Profile() {
             </Button>
           </CardContent>
         </Card>
+
+        {/* Swiss Fungi Integration */}
+        <SwissFungiPanel />
 
         {/* App Info */}
         <Card>

--- a/demo-swiss-fungi.js
+++ b/demo-swiss-fungi.js
@@ -9,8 +9,8 @@
  * 3. Fetching species information from Swiss Fungi database
  */
 
-import { swissFungiSync } from './server/swiss-fungi-sync.js';
-import { storage } from './server/storage.js';
+import { swissFungiSync } from './server/swiss-fungi-sync.ts';
+import { storage } from './server/storage.ts';
 
 async function runDemo() {
   console.log('🍄 Swiss Fungi Integration Demo\n');


### PR DESCRIPTION
Fix `WMSLayer`'s `useEffect` to include `onLoad` and `onError` in its dependency array. This resolves stale closure issues where event listeners referenced outdated callbacks, ensuring the effect re-runs when these props change and complies with React's rules of hooks.

---
<a href="https://cursor.com/background-agent?bcId=bc-4148819a-d779-466b-99e6-fed7a0565589">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4148819a-d779-466b-99e6-fed7a0565589">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

